### PR TITLE
Pet Details

### DIFF
--- a/app/components/Home/index.tsx
+++ b/app/components/Home/index.tsx
@@ -166,7 +166,7 @@ export default function Landing() {
             className="px-5 py-10 sm:px-7 sm:py-7 md:px-12 md:py-20 relative"
           >
             <div className="bg-lightBlue rounded-lg p-5 flex flex-col max-w-7xl mx-auto gap-y-5 relative overflow-hidden sm:p-12 md:p-20 md:gap-y-16">
-              <div className="flex flex-col gap-y-2 z-10 md:gap-y-4">
+              <div className="flex flex-col gap-y-2 md:z-10 md:gap-y-4">
                 <div className="flex flex-row justify-center items-center">
                   <DynamicTitle namespace={"Home"} translationKey={"processTitle"}/>
                   <Image
@@ -181,7 +181,7 @@ export default function Landing() {
                   </p>
                 </div>
               </div>
-              <div className="z-10">
+              <div className="md:z-10">
                 <Process></Process>
               </div>
 

--- a/app/components/Navigation/index.tsx
+++ b/app/components/Navigation/index.tsx
@@ -54,7 +54,6 @@ export default function Navigation({ isAdoption = false }: NavigationProps) {
   }, []);
 
   const changeLocale = (newLocale: string) => {
-    console.log(newLocale);
     setLocale(newLocale);
     setIsOpen(false);
     document.cookie = `KUTAAPP_LOCALE=${newLocale};`;

--- a/app/components/Pet/pet.tsx
+++ b/app/components/Pet/pet.tsx
@@ -87,6 +87,7 @@ export default function Pet({ isLanding = false }: PetProps) {
       }
     }
   }
+  
 
   return (
     <>
@@ -104,7 +105,7 @@ export default function Pet({ isLanding = false }: PetProps) {
               className={`rounded-lg border border-1 border-slate-300 overflow-hidden shrink-0 ${isLanding ? "sm:w-auto" : "sm:flex-1"}`}
             >
               <div className="relative group w-full overflow-hidden rounded-t-lg">
-                <div className="relative transition duration-300 group-hover:brightness-50">
+                <div className="relative transition duration-300 md:group-hover:brightness-50">
                   <div
                     className={`rounded-t-lg h-[300px] w-full ${isLanding ? "md:w-[300px] md:h-[300px]" : "md:w-[303px]"} `}
                     style={{
@@ -119,7 +120,7 @@ export default function Pet({ isLanding = false }: PetProps) {
                     </div>
                   </div>
                 </div>
-                <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition duration-300">
+                <div className="absolute hidden inset-0 md:flex items-center justify-center opacity-0 group-hover:opacity-100 transition duration-300">
                   <button onClick={() => {setQuickViewOpen(true); setSelectedIndex(index)}} className="text-white font-medium px-4 py-2 rounded-lg flex items-center gap-2 ">
                     <span
                       className="material-symbols-outlined"

--- a/app/components/Pet/pet.tsx
+++ b/app/components/Pet/pet.tsx
@@ -87,7 +87,7 @@ export default function Pet({ isLanding = false }: PetProps) {
       }
     }
   }
-  
+
 
   return (
     <>
@@ -121,7 +121,7 @@ export default function Pet({ isLanding = false }: PetProps) {
                   </div>
                 </div>
                 <div className="absolute hidden inset-0 md:flex items-center justify-center opacity-0 group-hover:opacity-100 transition duration-300">
-                  <button onClick={() => {setQuickViewOpen(true); setSelectedIndex(index)}} className="text-white font-medium px-4 py-2 rounded-lg flex items-center gap-2 ">
+                  <button onClick={() => { setQuickViewOpen(true); setSelectedIndex(index) }} className="text-white font-medium px-4 py-2 rounded-lg flex items-center gap-2 ">
                     <span
                       className="material-symbols-outlined"
                       style={{ fontSize: "24px" }}
@@ -190,31 +190,37 @@ export default function Pet({ isLanding = false }: PetProps) {
                     </p>
                   </div>
                 </div>
-
-                <div
-                  onClick={() => {
-                    if (
-                      localStorage.getItem("mascot-id")?.replace(/"/g, "") !==
-                      slug
-                    ) {
-                      localStorage.removeItem("adoption-answers");
-                      localStorage.removeItem("yes-no");
-                    }
-                  }}
-                  className="buttons w-full"
-                >
-                  <Button
-                    data={{
-                      title: t("apply"),
-                      type: "botones-primarios",
-                      metadata: {
-                        url: `/cuestionario?mascotId=${slug}`,
-                        color: "#594C81",
-                        sin_borde: false,
-                      },
+                <div className="flex flex-row gap-x-2">
+                  <button className="bg-purple rounded-lg text-white py-2 px-4 w-1/2 md:hidden font-inter font-medium hover:bg-purple"
+                  onClick={() => { setQuickViewOpen(true); setSelectedIndex(index) }}>
+                    {t("details")}
+                  </button>
+                  <div
+                    onClick={() => {
+                      if (
+                        localStorage.getItem("mascot-id")?.replace(/"/g, "") !==
+                        slug
+                      ) {
+                        localStorage.removeItem("adoption-answers");
+                        localStorage.removeItem("yes-no");
+                      }
                     }}
-                  />
+                    className="buttons md:w-full w-1/2"
+                  >
+                    <Button
+                      data={{
+                        title: t("apply"),
+                        type: "botones-primarios",
+                        metadata: {
+                          url: `/cuestionario?mascotId=${slug}`,
+                          color: "#594C81",
+                          sin_borde: false,
+                        },
+                      }}
+                    />
+                  </div>
                 </div>
+
               </div>
             </div>
           );

--- a/app/components/Pet/pet.tsx
+++ b/app/components/Pet/pet.tsx
@@ -7,12 +7,16 @@ import Button from "../../components/Button";
 import "./styles.sass";
 import "moment/locale/es";
 import { useTranslations } from "next-intl";
+import dayjs from 'dayjs';
+import { QuickView } from "./quickView";
 
 type PetProps = {
   isLanding?: boolean; // Optional, defaults to false (light background)
 };
 
 export default function Pet({ isLanding = false }: PetProps) {
+  const [isQuickViewOpen, setQuickViewOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [visibleCount, setVisibleCount] = useState(0);
   const [metadata, setMetadata] = useState({
     titulo: "",
@@ -31,8 +35,6 @@ export default function Pet({ isLanding = false }: PetProps) {
     };
     fetchMetadata();
   }, []);
-
-  console.log(metadata);
 
   useEffect(() => {
     const updateVisibleCount = () => {
@@ -66,7 +68,26 @@ export default function Pet({ isLanding = false }: PetProps) {
     Mediana: 'MD',
     Grande: 'LG',
   };
-  
+
+  function getAge(dateString: string): string {
+    const birthDate = dayjs(dateString);
+    const now = dayjs();
+
+    const years = now.diff(birthDate, 'year');
+
+    if (years >= 1) {
+      return `${years} ${years === 1 ? 'año' : 'años'}`;
+    } else {
+      if (years === 0) {
+        return 'N/A'
+      }
+      else {
+        const months = now.diff(birthDate, 'month');
+        return `${months} ${months === 1 ? 'mes' : 'meses'}`;
+      }
+    }
+  }
+
   return (
     <>
       <div className={`${isLanding ? "md:flex md:flex-row md:flex-wrap md:w-full" :
@@ -74,7 +95,7 @@ export default function Pet({ isLanding = false }: PetProps) {
       overflow-hidden gap-5 grid grid-cols-1 sm:grid-cols-2 w-full
       ${!isLanding ? "items-center" : "justify-center"}`}>
         {mascotasToRender.map((mascota: any, index: number) => {
-          const { title, metadata, slug } = mascota;
+          const { title, metadata, slug, descripcion_mascota } = mascota;
           const { raza, foto_mascota_1, fecha_de_resguardo, edad } = metadata;
 
           return (
@@ -82,21 +103,41 @@ export default function Pet({ isLanding = false }: PetProps) {
               key={index}
               className={`rounded-lg border border-1 border-slate-300 overflow-hidden shrink-0 ${isLanding ? "sm:w-auto" : "sm:flex-1"}`}
             >
-              <div className="relative">
-                <div
-                  className={`rounded-t-lg h-[300px] w-full ${isLanding ? "md:w-[300px] md:h-[300px]" : "md:w-[303px]"} `}
-                  style={{
-                    background: `url(${foto_mascota_1.imgix_url})`,
-                    backgroundSize: "cover",
-                    backgroundPosition: "top",
-                  }}
-                />
-                <div className="w-11 h-8 bg-white rounded-b-lg border border-slate-400 absolute top-0 right-3 border-t-0">
-                  <div className="w-full h-full flex justify-center items-center">
-                    <p className="font-inter text-slate-600">{sizeMap[metadata.talla?.value as string] || metadata.talla?.value}</p>
+              <div className="relative group w-full overflow-hidden rounded-t-lg">
+                <div className="relative transition duration-300 group-hover:brightness-50">
+                  <div
+                    className={`rounded-t-lg h-[300px] w-full ${isLanding ? "md:w-[300px] md:h-[300px]" : "md:w-[303px]"} `}
+                    style={{
+                      background: `url(${foto_mascota_1.imgix_url})`,
+                      backgroundSize: "cover",
+                      backgroundPosition: "top",
+                    }}
+                  />
+                  <div className="w-11 h-8 bg-white rounded-b-lg border border-slate-400 absolute top-0 right-3 border-t-0">
+                    <div className="w-full h-full flex justify-center items-center">
+                      <p className="font-inter text-slate-600">{sizeMap[metadata.talla?.value as string] || metadata.talla?.value}</p>
+                    </div>
                   </div>
                 </div>
+                <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition duration-300">
+                  <button onClick={() => {setQuickViewOpen(true); setSelectedIndex(index)}} className="text-white font-medium px-4 py-2 rounded-lg flex items-center gap-2 ">
+                    <span
+                      className="material-symbols-outlined"
+                      style={{ fontSize: "24px" }}
+                    >
+                      visibility
+                    </span>
+                    <p>{t("quickView")}</p>
+                  </button>
+                </div>
               </div>
+
+              {isQuickViewOpen && index === selectedIndex ?
+                <QuickView isOpen={isQuickViewOpen} onClose={() => setQuickViewOpen(false)} pet={mascota} metadata={metadata}>
+                </QuickView> : ''
+              }
+
+
 
               <div className="mascot-data p-5 gap-y-2 flex flex-col bg-white rounded-lg">
                 <div className="flex flex-row items-center justify-between gap-x-4">
@@ -132,8 +173,7 @@ export default function Pet({ isLanding = false }: PetProps) {
                     >
                       cake
                     </span>
-                    <p className="inter font-medium text-slate-600">{`${edad} ${edad !== 1 ? "años" : "año"
-                      }`}</p>
+                    <p className="inter font-medium text-slate-600">{`${getAge(edad)}`}</p>
                   </div>
                   <div className="flex items-center gap-x-2">
                     <span

--- a/app/components/Pet/quickView.tsx
+++ b/app/components/Pet/quickView.tsx
@@ -40,13 +40,14 @@ export function QuickView({ isOpen, onClose, pet, metadata }: QuickViewModalProp
     const t = useTranslations("Adoptions");
     const [selectedImage, setSelectedImage] = useState(metadata.foto_mascota_1.imgix_url)
     if (!isOpen) return null;
+    console.log(metadata);
 
     useEffect(() => {
         document.body.style.overflow = "hidden";
         return () => {
-          document.body.style.overflow = "";
+            document.body.style.overflow = "";
         };
-      }, []);
+    }, []);
 
     const sizeMap: Record<string, string> = {
         Pequeña: 'SM - Pequeño',
@@ -62,12 +63,12 @@ export function QuickView({ isOpen, onClose, pet, metadata }: QuickViewModalProp
     // ]
     const images = [
         metadata.foto_mascota_1.imgix_url,
-        ...(metadata.fotos_mascota || []),
+        ...(metadata.fotos_mascota || []).map((item: any) => item.foto.imgix_url),
     ]   
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-800/15">
-            <div className="bg-white rounded-lg w-[920px] p-10 relative shadow-xl">
+            <div className="bg-white rounded-lg w-full md:w-[920px] h-full md:h-auto py-10 px-4 sm:p-10 relative shadow-xl overflow-y-auto max-h-screen">
                 {/* Close Button */}
                 <button
                     onClick={onClose}
@@ -81,39 +82,38 @@ export function QuickView({ isOpen, onClose, pet, metadata }: QuickViewModalProp
                     </span>
                 </button>
 
-                <div className="flex flex-row gap-x-10">
-                    <div className="flex flex-row gap-x-5">
+                <div className="flex flex-col md:flex-row gap-x-10 gap-y-8">
+                    <div className="flex flex-col-reverse gap-y-2 sm:flex-row gap-x-5">
                         {metadata.fotos_mascota.length !== 0 ?
-                            <div className="flex flex-col gap-y-3 h-[400px] overflow-auto">
+                            <div className="flex flex-row sm:flex-col gap-y-3 gap-x-2 sm:h-[400px] overflow-auto justify-center sm:justify-start">
                                 {images.map((image: any, index: number) => {
                                     return (
                                         <div
                                             key={index}
                                             onClick={() => setSelectedImage(image)}
-                                            className={`rounded-md h-[150px] w-[120px] shrink-0 cursor-pointer ${selectedImage !== image ? 'opacity-50' : ''}`}
+                                            className={`rounded-md w-[70px] h-[70px] sm:h-[150px] sm:w-[120px] shrink-0 cursor-pointer ${selectedImage !== image ? 'opacity-50' : ''}`}
                                             style={{
                                                 background: `url(${image})`,
                                                 backgroundSize: "cover",
                                                 backgroundPosition: "center",
                                             }}
-                                        /> 
+                                        />
                                     )
                                 })}
                             </div> : ''
                         }
 
-                        <div
-                            key={selectedImage}
-                            className={`rounded-md h-[400px] w-[300px] shrink-0`}
-                            style={{
-                                background: `url(${selectedImage})`,
-                                backgroundSize: "cover",
-                                backgroundPosition: "center",
-                            }}
-                        />
+                        <div className="rounded-md h-[340px] w-full sm:flex-1 md:w-[300px] sm:h-[400px] overflow-auto">
+                            <img
+                                src={selectedImage}
+                                alt="Selected pet"
+                                className="w-auto h-auto min-h-full min-w-full"
+                                style={{ objectFit: 'cover' }}
+                            />
+                        </div>
                     </div>
 
-                    <div className="w-full flex flex-col justify-between">
+                    <div className="w-full flex flex-col justify-between gap-y-4">
                         <div className="flex flex-row justify-between items-center">
                             <h4 className="font-inter font-medium text-3xl text-slate-800">{pet.title}</h4>
                             <div

--- a/app/components/Pet/quickView.tsx
+++ b/app/components/Pet/quickView.tsx
@@ -1,0 +1,202 @@
+"use client"
+import moment from "moment";
+import Button from "../Button";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+type QuickViewModalProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    // pet: {
+    //   name: string;
+    //   images: [];
+    //   age: string;
+    //   breed: string;
+    //   description?: string;
+    // }
+    pet: {
+        title: string,
+        slug: string
+    },
+    metadata: {
+        foto_mascota_1: {
+            imgix_url: string
+        },
+        fotos_mascota: []
+        genero: {
+            value: string
+        },
+        descripcion_mascota: string,
+        fecha_de_resguardo: string,
+        "edad-numero": number,
+        raza: string,
+        talla: {
+            value: string
+        }
+    }
+};
+
+export function QuickView({ isOpen, onClose, pet, metadata }: QuickViewModalProps) {
+    const t = useTranslations("Adoptions");
+    const [selectedImage, setSelectedImage] = useState(metadata.foto_mascota_1.imgix_url)
+    if (!isOpen) return null;
+
+    const sizeMap: Record<string, string> = {
+        Pequeña: 'SM - Pequeño',
+        Mini: 'XS - Mini',
+        Mediana: 'MD - Mediano',
+        Grande: 'LG - Grande',
+    };
+
+    // const images = [
+    //     metadata.foto_mascota_1.imgix_url,
+    //     'https://brooklinelabrescue.org/wp-content/uploads/2023/09/image_67162625.jpg',
+    //     'https://www.thelabradorsite.com/wp-content/uploads/2017/05/english-lab.jpg'
+    // ]
+    const images = [
+        metadata.foto_mascota_1.imgix_url,
+        ...(metadata.fotos_mascota || []),
+    ]   
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-800/15">
+            <div className="bg-white rounded-lg w-[920px] p-10 relative shadow-xl">
+                {/* Close Button */}
+                <button
+                    onClick={onClose}
+                    className="absolute top-2 right-2 text-gray-500 hover:text-gray-800 text-xl"
+                >
+                    <span
+                        className="material-symbols-outlined text-slate-800"
+                        style={{ fontSize: "24px" }}
+                    >
+                        close
+                    </span>
+                </button>
+
+                <div className="flex flex-row gap-x-10">
+                    <div className="flex flex-row gap-x-5">
+                        {metadata.fotos_mascota.length !== 0 ?
+                            <div className="flex flex-col gap-y-3 h-[400px] overflow-auto">
+                                {images.map((image: any, index: number) => {
+                                    return (
+                                        <div
+                                            key={index}
+                                            onClick={() => setSelectedImage(image)}
+                                            className={`rounded-md h-[150px] w-[120px] shrink-0 cursor-pointer ${selectedImage !== image ? 'opacity-50' : ''}`}
+                                            style={{
+                                                background: `url(${image})`,
+                                                backgroundSize: "cover",
+                                                backgroundPosition: "center",
+                                            }}
+                                        /> 
+                                    )
+                                })}
+                            </div> : ''
+                        }
+
+                        <div
+                            key={selectedImage}
+                            className={`rounded-md h-[400px] w-[300px] shrink-0`}
+                            style={{
+                                background: `url(${selectedImage})`,
+                                backgroundSize: "cover",
+                                backgroundPosition: "center",
+                            }}
+                        />
+                    </div>
+
+                    <div className="w-full flex flex-col justify-between">
+                        <div className="flex flex-row justify-between items-center">
+                            <h4 className="font-inter font-medium text-3xl text-slate-800">{pet.title}</h4>
+                            <div
+                                className={`w-11 h-11 rounded-full flex justify-center items-center ${metadata.genero?.value === "Hembra"
+                                    ? "bg-rose-300"
+                                    : "bg-[#8EC5FF]"
+                                    }`}
+                            >
+                                <span
+                                    className="material-symbols-outlined text-white"
+                                    style={{ fontSize: "30px" }}
+                                >
+                                    {metadata.genero?.value === "Hembra"
+                                        ? "female"
+                                        : "male"}
+                                </span>
+                            </div>
+                        </div>
+                        {metadata.descripcion_mascota ?
+                            <div className="flex flex-col">
+                                <h5 className="font-inter font-medium text-lg text-slate-500">Personalidad</h5>
+                                <p className="font-inter text-slate-800" dangerouslySetInnerHTML={{
+                                    __html: metadata.descripcion_mascota,
+                                }}></p>
+                            </div> : ''}
+                        <div className="w-full rounded-md border border-slate-300 grid grid-cols-2 divide-solid divide-x divide-slate-300">
+                            <div className="flex justify-center items-center gap-x-2 p-3">
+                                <span
+                                    className="material-symbols-outlined text-slate-600"
+                                    style={{ fontSize: "22px" }}
+                                >
+                                    cake
+                                </span>
+                                <p className="inter font-medium text-slate-600">{metadata["edad-numero"]} {metadata["edad-numero"] != 1 ? 'años' : 'año'}</p>
+                            </div>
+                            <div className="flex justify-center items-center gap-x-2 p-3">
+                                <span
+                                    className="material-symbols-outlined text-slate-600"
+                                    style={{ fontSize: "22px" }}
+                                >
+                                    calendar_month
+                                </span>
+                                <p className="inter font-medium text-slate-600">
+                                    <span className="date">{`${moment(
+                                        new Date(metadata.fecha_de_resguardo)
+                                    ).fromNow()}`}</span>
+                                </p>
+                            </div>
+                        </div>
+                        <div className="flex flex-row gap-x-5">
+                            <div className="flex flex-col gap-y-2">
+                                <h5 className="font-inter text-slate-500 font-medium">Raza</h5>
+                                <div className="px-4 py-2 bg-slate-200 rounded-full flex justify-center text-slate-800 inter items-center capitalize">
+                                    {metadata.raza}
+                                </div>
+                            </div>
+                            <div className="flex flex-col gap-y-2">
+                                <h5 className="font-inter text-slate-500 font-medium">Tamaño</h5>
+                                <div className="px-4 py-2 bg-slate-200 rounded-full flex justify-center text-slate-800 inter items-center capitalize">
+                                    {sizeMap[metadata.talla?.value as string] || metadata.talla?.value}
+                                </div>
+                            </div>
+                        </div>
+                        <div
+                            onClick={() => {
+                                if (
+                                    localStorage.getItem("mascot-id")?.replace(/"/g, "") !==
+                                    pet.slug
+                                ) {
+                                    localStorage.removeItem("adoption-answers");
+                                    localStorage.removeItem("yes-no");
+                                }
+                            }}
+                            className="buttons w-full"
+                        >
+                            <Button
+                                data={{
+                                    title: "Aplicar",
+                                    type: "botones-primarios",
+                                    metadata: {
+                                        url: `/cuestionario?mascotId=${pet.slug}`,
+                                        color: "#594C81",
+                                        sin_borde: false,
+                                    },
+                                }}
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/components/Pet/quickView.tsx
+++ b/app/components/Pet/quickView.tsx
@@ -67,8 +67,9 @@ export function QuickView({ isOpen, onClose, pet, metadata }: QuickViewModalProp
     ]   
 
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-800/15">
-            <div className="bg-white rounded-lg w-full md:w-[920px] h-full md:h-auto py-10 px-7 sm:p-10 relative shadow-xl overflow-y-auto max-h-screen">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-800/15 "  onClick={onClose}>
+            <div className="bg-white rounded-lg w-full md:w-[920px] h-full md:h-auto py-10 px-7 sm:p-10 relative shadow-xl overflow-y-auto max-h-screen"
+            onClick={(e) => e.stopPropagation()}>
                 {/* Close Button */}
                 <button
                     onClick={onClose}

--- a/app/components/Pet/quickView.tsx
+++ b/app/components/Pet/quickView.tsx
@@ -68,7 +68,7 @@ export function QuickView({ isOpen, onClose, pet, metadata }: QuickViewModalProp
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-800/15">
-            <div className="bg-white rounded-lg w-full md:w-[920px] h-full md:h-auto py-10 px-4 sm:p-10 relative shadow-xl overflow-y-auto max-h-screen">
+            <div className="bg-white rounded-lg w-full md:w-[920px] h-full md:h-auto py-10 px-7 sm:p-10 relative shadow-xl overflow-y-auto max-h-screen">
                 {/* Close Button */}
                 <button
                     onClick={onClose}

--- a/app/components/Pet/quickView.tsx
+++ b/app/components/Pet/quickView.tsx
@@ -2,7 +2,7 @@
 import moment from "moment";
 import Button from "../Button";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type QuickViewModalProps = {
     isOpen: boolean;
@@ -40,6 +40,13 @@ export function QuickView({ isOpen, onClose, pet, metadata }: QuickViewModalProp
     const t = useTranslations("Adoptions");
     const [selectedImage, setSelectedImage] = useState(metadata.foto_mascota_1.imgix_url)
     if (!isOpen) return null;
+
+    useEffect(() => {
+        document.body.style.overflow = "hidden";
+        return () => {
+          document.body.style.overflow = "";
+        };
+      }, []);
 
     const sizeMap: Record<string, string> = {
         Pequeña: 'SM - Pequeño',

--- a/app/components/Social Media/socialMedia.tsx
+++ b/app/components/Social Media/socialMedia.tsx
@@ -1,4 +1,3 @@
-"use client"
 /* eslint-disable @next/next/no-sync-scripts */
 import facebook from "../../../assets/facebook.png";
 import instagram from "../../../assets/instagram.png";

--- a/app/components/Social Media/socialMedia.tsx
+++ b/app/components/Social Media/socialMedia.tsx
@@ -1,3 +1,4 @@
+"use client"
 /* eslint-disable @next/next/no-sync-scripts */
 import facebook from "../../../assets/facebook.png";
 import instagram from "../../../assets/instagram.png";
@@ -42,7 +43,6 @@ export default function SocialMedia() {
           <iframe
             src="//lightwidget.com/widgets/f84cca06d4fa57ca880793933996c1a5.html"
             scrolling="no"
-            allowTransparency
             className="lightwidget-widget"
             style={{width:"100%",border:0,overflow:"hidden", outline: "none"}}
           ></iframe>

--- a/app/cuestionario/components/cuestionario.tsx
+++ b/app/cuestionario/components/cuestionario.tsx
@@ -17,6 +17,7 @@ import { useLocalStorage } from "@/app/context/useLocalStorage";
 import AdoptionSteps from "@/app/components/AdoptionSteps/adoptionSteps";
 import Requirements from "@/app/components/Requirements/requirements";
 import { useTranslations } from "next-intl";
+import dayjs from "dayjs";
 
 const Questionnaire = () => {
   const t = useTranslations("AdoptionProcess")
@@ -201,6 +202,27 @@ const Questionnaire = () => {
     Grande: 'LG',
   };
 
+  moment.locale("es");
+
+  function getAge(dateString: string): string {
+      const birthDate = dayjs(dateString);
+      const now = dayjs();
+  
+      const years = now.diff(birthDate, 'year');
+  
+      if (years >= 1) {
+        return `${years} ${years === 1 ? 'año' : 'años'}`;
+      } else {
+        if(years === 0){
+          return 'N/A'
+        }
+        else{
+          const months = now.diff(birthDate, 'month');
+        return `${months} ${months === 1 ? 'mes' : 'meses'}`;
+        }
+      }
+    }
+
   const sendForm = async () => {
     setSent(true);
     const ok = await postForm(answers, title, secciones);
@@ -374,8 +396,7 @@ const Questionnaire = () => {
                         >
                           cake
                         </span>
-                        <p className="inter font-medium text-slate-600">{`${edad} ${Number(edad) !== 1 ? "años" : "año"
-                          }`}</p>
+                        <p className="inter font-medium text-slate-600">{getAge(edad)}</p>
                       </div>
                       <div className="flex items-center gap-x-2">
                         <span

--- a/messages/en.json
+++ b/messages/en.json
@@ -180,6 +180,7 @@
                 "Shelter"
             ]
         },
+        "details": "Details",
         "quickView": "Quick View"
     },
     "AdoptionProcess": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -179,7 +179,8 @@
                 "Pets in",
                 "Shelter"
             ]
-        }
+        },
+        "quickView": "Quick View"
     },
     "AdoptionProcess": {
         "important": "Important",

--- a/messages/es.json
+++ b/messages/es.json
@@ -180,6 +180,7 @@
                 "Resguardo"
             ]
         },
+        "details": "Detalles",
         "quickView": "Vista Rápida"
     },
     "AdoptionProcess": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -179,7 +179,8 @@
                 "Mascotas en",
                 "Resguardo"
             ]
-        }
+        },
+        "quickView": "Vista Rápida"
     },
     "AdoptionProcess": {
         "important": "Importante",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vercel/analytics": "^1.5.0",
     "axios": "^1.7.2",
     "cosmicjs": "^5.0.2",
+    "dayjs": "^1.11.13",
     "framer-motion": "^11.2.9",
     "moment": "^2.30.1",
     "next": "^14.2.3",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,6 +23,7 @@ const config: Config = {
         bgPurple: '#CEC8DF',
         lightPink: '#FCF3F3',
         lightBlue: '#D0E8F1',
+        lightPurple: "#A69CC4",
         gradientBlue: '#D5EBF3',
         gradientPurple: '#D2C5F9',
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,6 +2907,11 @@ damerau-levenshtein@^1.0.8:
   resolved "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
+dayjs@^1.11.13:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
@@ -4688,7 +4693,16 @@ streamsearch@^1.1.0:
   resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4748,7 +4762,14 @@ string.prototype.trimstart@^1.0.7:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
Added the functionality to view the details of a pet from the pet card. 

On desktop: Hovering the mouse over pet image darkens the image and shows a button in the center that says "quick view". On press of this button, a modal appears over the viewport, positioned at the center. Here, the user can view the image of the pet, and if there are more images, can also view those. The same information from the card is displayed within this modal with the addition of a personality description, if it exists. From here, the user can also press the button to start the adoption process.

On Tablet and Mobile: The hovering functionality is removed. Instead, a button appears before the Apply button with the label "Details". Clicking on this button activates the same modal. However, in these cases, the modal takes up the entire width and height of the viewport. The same information is shown with the only change being the layout. To exit this modal, the user must press the close button locating in the top right corner. 

